### PR TITLE
Update fetcher.py

### DIFF
--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -126,7 +126,7 @@ class Fetcher:
             models.WriteQuery(
                 model="i__looker",
                 view="history",
-                fields=["history.query_run_count, query.model"],
+                fields=["history.query_run_count", "query.model"],
                 filters={
                     "history.created_date": self.timeframe,
                     "query.model": "-system^_^_activity, -i^_^_looker",


### PR DESCRIPTION
The `get_used_explores` method in `fetcher.py` had a typographic error, preventing the `henry analyze models` and other dependent commands executing.

This commit fixes that.